### PR TITLE
Fix the wrong pid on EngineCoolantTemperature

### DIFF
--- a/tools/cloud/obd-decoders.json
+++ b/tools/cloud/obd-decoders.json
@@ -1302,7 +1302,7 @@
         "obdSignal": {
             "byteLength": 1,
             "offset": 0,
-            "pid": 103,
+            "pid": 5,
             "pidResponseLength": 3,
             "scaling": 1,
             "serviceMode": 1,


### PR DESCRIPTION
According to `./datamanagement/types/include/OBDDataTypes.h` definition, the pid of EngineCoolantTemperature should be 0X05.

```
150 enum class EmissionPIDs
151 {
152     PIDS_SUPPORTED_01_20                                                           = 0X00,
153     FUEL_SYSTEM_STATUS                                                             = 0X03,
154     ENGINE_LOAD                                                                    = 0X04,
155     ENGINE_COOLANT_TEMPERATURE                                                     = 0X05,
156     SHORT_TERM_FUEL_TRIM_BANK_1                                                    = 0X06,
157     LONG_TERM_FUEL_TRIM_BANK_1                                                     = 0X07,
158     SHORT_TERM_FUEL_TRIM_BANK_2                                                    = 0X08,
````

When the campaign is triggered on the demo script, it will use `obd-decoders.json` as the decoder manifest with OBD signals, however, the `pid` definition on the `obd-decoders.json` is different to the `OBDDataTypes.h` defined. It causes the issue that the `Vehicle.OBD.EngineCoolantTemperature` data can't be collected on FleetWise.

```
1298     {
1299         "fullyQualifiedName": "Vehicle.OBD.EngineCoolantTemperature",
1300         "interfaceId": "0",
1301         "type": "OBD_SIGNAL",
1302         "obdSignal": {
1303             "byteLength": 1,
1304             "offset": 0,
1305             "pid": 103,
1306             "pidResponseLength": 3,
1307             "scaling": 1,
1308             "serviceMode": 1,
1309             "startByte": 0,
1310             "bitMaskLength": 8,
1311             "bitRightShift": 0
1312         }
1313     },
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
