### PR TITLE
Limit the supported PID Range below 0xC0

### DIFF
--- a/src/datamanagement/types/include/OBDDataTypes.h
+++ b/src/datamanagement/types/include/OBDDataTypes.h
@@ -283,7 +283,7 @@ enum class EmissionPIDs
 
 static constexpr uint8_t SUPPORTED_PID_STEP = 0x20;
 
-static constexpr std::array<PID, 7> supportedPIDRange = { { 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0 } };
+static constexpr std::array<PID, 6> supportedPIDRange = { { 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0 } };
 
 // This table contains a local copy of OBD-II PID decoding method from J1979. It's only used by unit test.
 // The actual Edge Agent will only use decoding manifest received from AWS


### PR DESCRIPTION
fixes  #10 

**Describe the bug**
The engine ECU from an old vehicle model would respond `127, 1, 18` if the edge agent request supported PIDs by sending `0x01, 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0`. Hence we need to remove the 0xC0 from the message to support this older model. As FleetWise Decoder Manifest doesn't support any OBD PID above 0xC0, limiting the range below 0xC0 can be an acceptable solution for the near term.

**To Reproduce**
This issue was caught on an old vehicle model with release v0.1.4.

**Expected behavior**
The ECU should respond the supported PIDs correctly.

**Logs**
Before the fix
```
[TRACE] [OBDOverCANModule::doWork]: [Requesting Supported PIDs from Engine ECU]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [send supported PID requests]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [TxPDU: 1,0,32,64,96,128,160,192]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:8]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:3]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 127,1,18]
[WARN] [OBDDataDecoder::decodeSupportedPIDs]: [Invalid Supported PID Input]
[ERROR] [OBDOverCANModule::doWork]: [Failed to request/receive Engine ECU PIDs for SID: 1]
```
After limiting the range below 0xC0 (192). The ECU responded correctly.
```
[TRACE] [OBDOverCANModule::doWork]: [Requesting Supported PIDs from Engine ECU]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [send supported PID requests]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [TxPDU: 1,0,32,64,96,128,160]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:7]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:21]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 65,0,191,190,168,147,32,145,7,224,25,64,250,220,128,1,96,4,0,0,0]
[TRACE] [OBDOverCANModule::doWork]: [Engine ECU supports PIDs for SID 1: 1,3,4,5,6,7,8,9,11,12,13,14,15,17,19,21,25,28,31,33,36,40,46,47,48,49,50,51,60,61,65,66,67,68,69,71,73,74,76,77,78,81,102]
[TRACE] [OBDOverCANModule::updatePIDRequestList]: [The PIDs to Request from Engine ECU are: 12,13,17,47]
```

**Environment (please complete the following information):**
 - OS: Linux kernel version: 5.4.70
 - Architecture: armv7l
 - Vehicle year: 2012

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
