### PR TITLE
Request PID range 0xC0, 0xE0 in a separate message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## future release (TBD)
+Bugfixes:
+* Fixed an OBD bug in which software requests more than six PID ranges in one message. The new revision request the extra range in a separate message.
+
 ## v0.1.4 (Aug 29, 2022)
 https://s3.console.aws.amazon.com/s3/object/aws-iot-fleetwise?prefix=v0.1.4/aws-iot-fleetwise-edge.zip
 

--- a/src/datamanagement/datainspection/include/OBDOverCANModule.h
+++ b/src/datamanagement/datainspection/include/OBDOverCANModule.h
@@ -169,9 +169,6 @@ private:
     // output buffer
     static void doWork( void *data );
 
-    // Issues a supported PID request to the specific ECU and SID
-    bool requestSupportedPIDs( const SID &sid, ISOTPOverCANSenderReceiver &isoTPSendReceive );
-
     // Receives the supported PID request to the specific ECU and SID
     bool receiveSupportedPIDs( const SID &sid,
                                ISOTPOverCANSenderReceiver &isoTPSendReceive,
@@ -204,6 +201,7 @@ private:
     bool receiveDTCs( const SID &sid, ISOTPOverCANSenderReceiver &isoTPSendReceive, DTCInfo &info );
     bool requestReceiveDTCs( const SID &sid, ISOTPOverCANSenderReceiver &isoTPSendReceive, DTCInfo &info );
 
+    static constexpr size_t MAX_PID_RANGE = 6U;
     Thread mThread;
     std::atomic<bool> mShouldStop{ false };
     std::atomic<bool> mDecoderManifestAvailable{ false };

--- a/src/datamanagement/types/include/OBDDataTypes.h
+++ b/src/datamanagement/types/include/OBDDataTypes.h
@@ -278,16 +278,17 @@ enum class EmissionPIDs
     TRANSMISSION_ACTUAL_GEAR                                                       = 0XA4,
     ODOMETER                                                                       = 0XA6,
     PIDS_SUPPORTED_C1_E0                                                           = 0XC0,
+    HVESS_RECOMMENDED_MAX_SOC                                                      = 0xC1
 };
 // clang-format on
 
 static constexpr uint8_t SUPPORTED_PID_STEP = 0x20;
 
-static constexpr std::array<PID, 7> supportedPIDRange = { { 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0 } };
+static constexpr std::array<PID, 8> supportedPIDRange = { { 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0, 0xE0 } };
 
-// This table contains a local copy of OBD-II PID decoding method from J1979. It's only used by unit test.
+// This table is only used by unit test.
 // The actual Edge Agent will only use decoding manifest received from AWS
-const std::array<struct PIDInfo, 171> mode1PIDs = { {
+const std::array<struct PIDInfo, 172> mode1PIDs = { {
     { 0x00, 4, { { 0, 1.0, 0, 4 } } }, // PIDs supported [01 - 20]
     { 0x01, 4, { {} } },               // Monitor status since DTCs cleared.(MIL) status and number of DTCs.
     { 0x02, 2, { {} } },               // Freeze DTC
@@ -647,7 +648,8 @@ const std::array<struct PIDInfo, 171> mode1PIDs = { {
     { 0xA4, 4, { { 0, 1.0, 0, 1 }, { 1, 4, 4 }, { 2, 0.001, 0, 2 } } }, // Transmission Actual Gear
     { 0xA5, 4, { {} } },                                                // Diesel Exhaust Fluid Dosing
     { 0xA6, 4, { { 0, 0.1, 0, 4 } } },                                  // Odometer
-    { 0xC0, 4, { { 0, 1.0, 0, 4 } } }                                   // PIDs supported [C1 - E0]
+    { 0xC0, 4, { { 0, 1.0, 0, 4 } } },                                  // PIDs supported [C1 - E0]
+    { 0xC1, 1, { {} } }                                                 // HVESS Recommended Maximum State Of Charge
 } };
 
 // Mode 2
@@ -718,7 +720,7 @@ getPID( SID sid, size_t index )
     switch ( sid )
     {
     case SID::CURRENT_STATS:
-        if ( static_cast<PID>( index ) < supportedPIDRange.back() + SUPPORTED_PID_STEP )
+        if ( index < supportedPIDRange.back() + SUPPORTED_PID_STEP )
         {
             returnPID = static_cast<PID>( index );
         }


### PR DESCRIPTION
fixes  #10 

**Describe the bug**
Per specification from ISO15765 in J1979, maximum six PID can be sent out to ECU. In v0.1.4, seven PIDs were sent to ECU to request supported PID list: 0x00, 0x20, 0x40, 0x60, 0x80, 0xA0, 0xC0.

**To Reproduce**
This issue was caught on an old vehicle model which respond 0x7F, 0x01, 0x12 due to requesting PID 0xC0.

**Expected behavior**
1. Software shall not request more than six PIDs at one time. 
2. Although ECU respond 0x7F, 0x01, 0x12 for PID 0xC0, software shall still get the supported PIDs in other ranges.

**Fix**
Moved the extra PID range (0xC0, 0xE0) request to the second message

**Logs**
Before the fix. The log collected from vehicle whose ECU follow ISO 14230
```
[TRACE] [OBDOverCANModule::doWork]: [Requesting Supported PIDs from Engine ECU]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [send supported PID requests]
[TRACE] [OBDOverCANModule::requestSupportedPIDs]: [TxPDU: 1,0,32,64,96,128,160,192]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:8]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:3]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 127,1,18]
[WARN] [OBDDataDecoder::decodeSupportedPIDs]: [Invalid Supported PID Input]
[ERROR] [OBDOverCANModule::doWork]: [Failed to request/receive Engine ECU PIDs for SID: 1]
```
After the fix. Software can correctly handle the ECU response
```
[TRACE] [OBDOverCANModule::doWork]: [Requesting Supported PIDs from Engine ECU]
[TRACE] [OBDOverCANModule::requestReceiveSupportedPIDs]: [send supported PID requests]
[TRACE] [OBDOverCANModule::requestPIDs]: [Transmit PDU: 1,0,32,64,96,128,160]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:7]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:21]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 65,0,191,190,168,147,32,145,7,224,25,64,250,220,128,1,96,4,0,0,0]
[TRACE] [OBDOverCANModule::requestPIDs]: [Transmit PDU: 1,192,224]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:3]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:3]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 127,1,18]
[WARN] [OBDDataDecoder::decodeSupportedPIDs]: [Invalid Supported PID Input]
[TRACE] [OBDOverCANModule::doWork]: [Engine ECU supports PIDs for SID 1: 1,3,4,5,6,7,8,9,11,12,13,14,15,17,19,21,25,28,31,33,36,40,46,47,48,49,50,51,60,61,65,66,67,68,69,71,73,74,76,77,78,81,102]
```
Tested on newer model of vehicle with ISO15765
```
[TRACE] [OBDOverCANModule::doWork]: [Requesting Supported PIDs from Engine ECU]
[TRACE] [OBDOverCANModule::requestReceiveSupportedPIDs]: [send supported PID requests]
[TRACE] [OBDOverCANModule::requestPIDs]: [Transmit PDU: 1,0,32,64,96,128,160]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:7]
[TRACE] [ISOTPOverCANSenderReceiver::receivePDU]: [ Received a PDU of size:21]
[TRACE] [OBDOverCANModule::receiveSupportedPIDs]: [ECU Response: 65,0,190,61,168,19,32,144,31,176,17,64,254,220,160,81,96,9,8,0,0]
[TRACE] [OBDOverCANModule::requestPIDs]: [Transmit PDU: 1,192,224]
[TRACE] [ISOTPOverCANSenderReceiver::sendPDU]: [ sent a PDU of size:3]
[TRACE] [OBDOverCANModule::doWork]: [Engine ECU supports PIDs for SID 1: 1,3,4,5,6,7,11,12,13,14,16,17,19,21,28,31,33,36,44,45,46,47,48,49,51,52,60,65,66,67,68,69,70,71,73,74,76,77,78,81,83,90,92,101,104,109]
```

**Environment (please complete the following information):**
 - OS: Linux kernel version: 5.4.70
 - Architecture: armv7l
 - Test Vehicle year / region: 2012 USA, 2016 USA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.