### PR TITLE
rpi tutorial corrections

### DIFF
--- a/docs/rpi-tutorial/raspberry-pi-tutorial.md
+++ b/docs/rpi-tutorial/raspberry-pi-tutorial.md
@@ -52,8 +52,8 @@ sudo apt install -y unzip
 8. Run `sudo nano /boot/firmware/usercfg.txt` and add the following lines to enable the CAN hat:
 ```
 dtparam=spi=on
-dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=23
 dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=25
+dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=23
 dtoverlay=spi-bcm2835-overlay
 ```
 9. Save the file (`CTRL+O`, `CTRL+X`) and reboot the Raspberry Pi (`sudo reboot`).

--- a/docs/rpi-tutorial/raspberry-pi-tutorial.md
+++ b/docs/rpi-tutorial/raspberry-pi-tutorial.md
@@ -52,8 +52,8 @@ sudo apt install -y unzip
 8. Run `sudo nano /boot/firmware/usercfg.txt` and add the following lines to enable the CAN hat:
 ```
 dtparam=spi=on
-dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25
-dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=23
+dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=23
+dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=25
 dtoverlay=spi-bcm2835-overlay
 ```
 9. Save the file (`CTRL+O`, `CTRL+X`) and reboot the Raspberry Pi (`sudo reboot`).

--- a/docs/rpi-tutorial/raspberry-pi-tutorial.md
+++ b/docs/rpi-tutorial/raspberry-pi-tutorial.md
@@ -53,7 +53,7 @@ sudo apt install -y unzip
 ```
 dtparam=spi=on
 dtoverlay=mcp2515-can0,oscillator=16000000,interrupt=25
-dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=25
+dtoverlay=mcp2515-can1,oscillator=16000000,interrupt=23
 dtoverlay=spi-bcm2835-overlay
 ```
 9. Save the file (`CTRL+O`, `CTRL+X`) and reboot the Raspberry Pi (`sudo reboot`).
@@ -61,13 +61,13 @@ dtoverlay=spi-bcm2835-overlay
     [AWS IoT FleetWise Edge Agent Developer Guide](../dev-guide/edge-agent-dev-guide.md#provision-aws-iot-credentials).
 11. Install the [can-isotp](https://en.wikipedia.org/wiki/ISO_15765-2) module:
 ```
-sudo ~/aws-iot-fleetwise-deploy/tools/install-socketcan.sh
+sudo ~/aws-iot-fleetwise-edge/tools/install-socketcan.sh
 ```
 12. Run `sudo nano /usr/local/bin/setup-socketcan.sh` and add the following lines to bring up the
     `can0` and `can1` interfaces at startup:
 ```
-ip link set up can0 txqueuelen 1000 type can bitrate 500000 restart-ms 100
-ip link set up can1 txqueuelen 1000 type can bitrate 500000 restart-ms 100
+sudo ip link set up can0 txqueuelen 1000 type can bitrate 500000 restart-ms 100
+sudo ip link set up can1 txqueuelen 1000 type can bitrate 500000 restart-ms 100
 ```
 13. Restart the setup-socketcan service and the IoT FleetWise Edge Agent service:
 ```


### PR DESCRIPTION
- Corrected wrong interrupt number for _can0_ (for _2-CH CAN HAT_ INT_0 is soldered by PIN23 by default, and INT_1 is soldered by PIN25 by default)
- Corrected command path to run _install-socketcan.sh_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
