### PR TITLE
Fix for error when running install-socketcan.sh on system with kernel >5.10

### DIFF
--- a/docs/rpi-tutorial/raspberry-pi-tutorial.md
+++ b/docs/rpi-tutorial/raspberry-pi-tutorial.md
@@ -66,8 +66,8 @@ sudo ~/aws-iot-fleetwise-edge/tools/install-socketcan.sh
 12. Run `sudo nano /usr/local/bin/setup-socketcan.sh` and add the following lines to bring up the
     `can0` and `can1` interfaces at startup:
 ```
-sudo ip link set up can0 txqueuelen 1000 type can bitrate 500000 restart-ms 100
-sudo ip link set up can1 txqueuelen 1000 type can bitrate 500000 restart-ms 100
+ip link set up can0 txqueuelen 1000 type can bitrate 500000 restart-ms 100
+ip link set up can1 txqueuelen 1000 type can bitrate 500000 restart-ms 100
 ```
 13. Restart the setup-socketcan service and the IoT FleetWise Edge Agent service:
 ```


### PR DESCRIPTION
- Fixed error when running `install-socketcan.sh` on system with kernel >5.10: added condition to check if `can-isotp` is already in system. Checked on an old Raspberry Pi B+ with `Linux raspberrypi 5.10.103+ #1529 Tue Mar 8 12:19:18 GMT 2022 armv6l GNU/Linux`.
- Deleted back mistakenly added `sudo` in rpi readme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
