### PR TITLE
Add docker container images for amd64 and arm64

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,0 +1,52 @@
+name: Publish Container Images
+
+on:
+  push:
+    branches: [ $default-branch ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ $default-branch ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: "./tools/container/Dockerfile"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/tools/container/Dockerfile
+++ b/tools/container/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04 as build-step
+
+ARG version=v1.0.0
+LABEL version=${version}
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    git ca-certificates iproute2 can-utils jq sed && \
+    apt-get clean
+WORKDIR /root
+RUN git clone --depth 1 --branch ${version} https://github.com/aws/aws-iot-fleetwise-edge.git && \
+    cd /root/aws-iot-fleetwise-edge/ && \
+    sed -i 's/sudo//g' ./tools/install-deps-native.sh && \
+    ./tools/install-deps-native.sh && \
+    ./tools/build-fwe-native.sh 
+
+FROM ubuntu:18.04
+
+LABEL version=${version}
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    ca-certificates iproute2 can-utils jq sed \
+    curl zlib1g-dev libcurl4-openssl-dev && \
+    apt-get clean
+WORKDIR /root
+
+COPY --from=build-step /root/aws-iot-fleetwise-edge/build/src/executionmanagement/aws-iot-fleetwise-edge /usr/bin/
+COPY --from=build-step /root/aws-iot-fleetwise-edge/tools/configure-fwe.sh /usr/bin/
+COPY --from=build-step /root/aws-iot-fleetwise-edge/configuration/static-config.json /etc/
+
+ADD tools/container/start-fwe.sh /usr/bin
+RUN chmod +x /usr/bin/start-fwe.sh
+
+ENTRYPOINT /usr/bin/start-fwe.sh

--- a/tools/container/start-fwe.sh
+++ b/tools/container/start-fwe.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+if [[ -z "$CAN_IF" ]]; then
+    echo "Must provide CAN_IF in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$VEHICLE_NAME" ]]; then
+    echo "Must provide VEHICLE_NAME in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$FW_ENDPOINT" ]]; then
+    echo "Must provide FW_ENDPOINT in environment" 1>&2
+    exit 1
+fi
+
+function ifup {
+    typeset output
+    output=$(ip link show "$1" up) && [[ -n $output ]]
+}
+
+while : ; do
+    if ifup $CAN_IF; then
+        break
+    else
+        echo "Waiting for $CAN_IF"
+        sleep 3
+    fi
+done
+
+mkdir -p /var/aws-iot-fleetwise
+mkdir -p /etc/fwe
+/usr/bin/configure-fwe.sh \
+        --input-config-file /etc/static-config.json \
+        --output-config-file /etc/aws-iot-fleetwise/config-0.json \
+        --vehicle-name $VEHICLE_NAME \
+        --endpoint-url $FW_ENDPOINT \
+        --can-bus0 $CAN_IF 
+[[ $TRACE == "on" ]]  && sed -i 's/Info/Trace/' /etc/aws-iot-fleetwise/config-0.json 
+cat /etc/aws-iot-fleetwise/config-0.json
+/usr/bin/aws-iot-fleetwise-edge /etc/aws-iot-fleetwise/config-0.json


### PR DESCRIPTION
This PR adds a new workflow that will produce docker container images for two arch: amd64 and arm64.
The images are a new way to quickly execute fleetwise agent on a container runtime such as the one included into EWOAL, SOAFEE reference implementation.
