### PR TITLE
Fix build and install

### DIFF
--- a/src/datamanagement/datacollection/CMakeLists.txt
+++ b/src/datamanagement/datacollection/CMakeLists.txt
@@ -46,7 +46,6 @@ install(TARGETS ${libraryTargetName} DESTINATION lib)
 install(
   FILES
   include/CANInterfaceIDTranslator.h
-  include/CollectionFileUploadManager.h
   include/CollectionScheme.h
   include/CollectionSchemeIngestion.h
   include/CollectionSchemeIngestionList.h

--- a/src/datamanagement/datainspection/src/diag/OBDOverCANModule.cpp
+++ b/src/datamanagement/datainspection/src/diag/OBDOverCANModule.cpp
@@ -341,10 +341,10 @@ OBDOverCANModule::autoDetectECUs( bool isExtendedID, std::vector<uint32_t> &canI
         // 11-bit range 7E8, 7E9, 7EA ... 7EF ==> [7E8, 7EF]
         // 29-bit range: [18DAF100, 18DAF1FF]
         auto frameCANId = ( isExtendedID ) ? ( frame.can_id & CAN_EFF_MASK ) : frame.can_id;
-        auto smallestCANId = ( isExtendedID ) ? ( u_int32_t )( ECUID::LOWEST_ECU_EXTENDED_RX_ID )
-                                              : ( u_int32_t )( ECUID::LOWEST_ECU_RX_ID );
-        auto biggestCANId = ( isExtendedID ) ? ( u_int32_t )( ECUID::HIGHEST_ECU_EXTENDED_RX_ID )
-                                             : ( u_int32_t )( ECUID::HIGHEST_ECU_RX_ID );
+        auto smallestCANId = ( isExtendedID ) ? ( uint32_t )( ECUID::LOWEST_ECU_EXTENDED_RX_ID )
+                                              : ( uint32_t )( ECUID::LOWEST_ECU_RX_ID );
+        auto biggestCANId = ( isExtendedID ) ? ( uint32_t )( ECUID::HIGHEST_ECU_EXTENDED_RX_ID )
+                                             : ( uint32_t )( ECUID::HIGHEST_ECU_RX_ID );
         // Check if CAN ID is valid
         if ( smallestCANId <= frameCANId && frameCANId <= biggestCANId )
         {

--- a/src/executionmanagement/src/IoTFleetWiseEngine.cpp
+++ b/src/executionmanagement/src/IoTFleetWiseEngine.cpp
@@ -11,6 +11,7 @@
 #include "businterfaces/AbstractVehicleDataSource.h"
 #include "businterfaces/CANDataSource.h"
 #include <boost/lockfree/spsc_queue.hpp>
+#include <fstream>
 
 namespace Aws
 {


### PR DESCRIPTION
Resolves a few build and install errors encountered with GCC 11.3.0 using musl 1.1.24.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
