### PR TITLE
Rename CANDataSource to SocketCANDataSource

### DIFF
--- a/configuration/static-config.json
+++ b/configuration/static-config.json
@@ -2,13 +2,13 @@
     "version": "1.0",
     "networkInterfaces": [
         {
-            "canInterface": {
+            "socketCANInterface": {
                 "interfaceName": "vcan0",
                 "protocolName": "CAN",
                 "protocolVersion": "2.0A"
             },
             "interfaceId": "1",
-            "type": "canInterface"
+            "type": "socketCANInterface"
         },
         {
             "obdInterface": {

--- a/docs/dev-guide/edge-agent-dev-guide.md
+++ b/docs/dev-guide/edge-agent-dev-guide.md
@@ -1335,7 +1335,7 @@ Customers can set the System level logging severity externally via the software 
 
 | Category                 | Attributes                                  | Description                                            | DataType |
 | ------------------------ | ------------------------------------------- | -------------------------------------------------------| -------- |
-| canInterface             | interfaceName                               | Interface name for CAN network                                                                                            | string   |
+| socketCANInterface       | interfaceName                               | Interface name for CAN network                                                                                            | string   |
 |                          | protocolName                                | Protocol used- CAN or CAN-FD                                                                                              | string   |
 |                          | protocolVersion                             | Protocol version used- 2.0A, 2.0B.                                                                                        | string   |
 |                          | interfaceId                                 | Every CAN signal decoder is associated with a CAN network interface using a unique Id                                     | string   |
@@ -1523,13 +1523,13 @@ The following documents or websites provide more information about AWS IoT Fleet
   "version": "1.0",
   "networkInterfaces": [
     {
-      "canInterface": {
+      "socketCANInterface": {
         "interfaceName": "vcan0",
         "protocolName": "CAN",
         "protocolVersion": "2.0B"
       },
       "interfaceId": "1",
-      "type": "canInterface"
+      "type": "socketCANInterface"
     },
     {
       "obdInterface": {

--- a/interfaces/protobuf/schemas/edgeConfiguration/staticConfiguration.json
+++ b/interfaces/protobuf/schemas/edgeConfiguration/staticConfiguration.json
@@ -16,7 +16,7 @@
             "anyOf": [
                 {
                     "required": [
-                        "canInterface"
+                        "socketCANInterface"
                     ]
                 },
                 {
@@ -26,12 +26,12 @@
                 }
             ],
             "properties": {
-                "canInterface": {
+                "socketCANInterface": {
                     "type": "object",
                     "additionalProperties": false,
-                    "description": "CAN Signal network interface information",
+                    "description": "SocketCAN Signal network interface information",
                     "items": {
-                        "$ref": "#/definitions/canInterface"
+                        "$ref": "#/definitions/socketCANInterface"
                     }
                 },
                 "obdInterface": {
@@ -52,7 +52,7 @@
                 }
             },
             "definitions": {
-                "canInterface": {
+                "socketCANInterface": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {

--- a/src/datamanagement/datainspection/test/VehicleDataSourceBinderTest.cpp
+++ b/src/datamanagement/datainspection/test/VehicleDataSourceBinderTest.cpp
@@ -7,7 +7,7 @@
 #include "IActiveDecoderDictionaryListener.h"
 #include "Signal.h"
 #include "Thread.h"
-#include "businterfaces/CANDataSource.h"
+#include "businterfaces/SocketCANDataSource.h"
 #include <functional>
 #include <gtest/gtest.h>
 #include <linux/can.h>
@@ -434,8 +434,8 @@ protected:
         canSourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
         canSourceConfig.maxNumberOfVehicleDataMessages = 1000;
         std::vector<VehicleDataSourceConfig> canSourceConfigs = { canSourceConfig };
-        canSourcePtr = std::make_shared<CANDataSource>();
-        canSourcePtr2 = std::make_shared<CANDataSource>();
+        canSourcePtr = std::make_shared<SocketCANDataSource>();
+        canSourcePtr2 = std::make_shared<SocketCANDataSource>();
         ASSERT_TRUE( canSourcePtr->init( canSourceConfigs ) );
         ASSERT_TRUE( canSourcePtr2->init( canSourceConfigs ) );
         sourceID = canSourcePtr->getVehicleDataSourceID();
@@ -759,13 +759,13 @@ TEST_F( VehicleDataSourceBinderTest, VehicleDataSourceBinderTestDiscardInputBuff
  */
 TEST_F( VehicleDataSourceBinderTest, VehicleDataSourceBinderStartupAndShutdownCycle )
 {
-    std::shared_ptr<CANDataSource> canSource;
+    std::shared_ptr<SocketCANDataSource> canSource;
     std::shared_ptr<CANDataConsumer> canConsumer;
     std::shared_ptr<const CANDecoderDictionary> dictionary;
     VehicleDataSourceID sourceID;
     VehicleDataSourceBinder networkBinder;
     ASSERT_TRUE( socketFD != -1 );
-    canSource = std::make_shared<CANDataSource>();
+    canSource = std::make_shared<SocketCANDataSource>();
     VehicleDataSourceConfig canSourceConfig;
     canSourceConfig.transportProperties.emplace( "interfaceName", "vcan0" );
     canSourceConfig.transportProperties.emplace( "protocolName", "CAN" );

--- a/src/executionmanagement/test/em-example-config-corrupt.json
+++ b/src/executionmanagement/test/em-example-config-corrupt.json
@@ -6,7 +6,7 @@
         "FWE Corrupt File test"
     ],
     "staticConfig": {
-        "canInterface": [
+        "socketCANInterface": [
             "FWE Corrupt File test"
         ]
     }

--- a/src/executionmanagement/test/em-example-config.json
+++ b/src/executionmanagement/test/em-example-config.json
@@ -2,13 +2,13 @@
     "version": "1.0",
     "networkInterfaces": [
         {
-            "canInterface": {
+            "socketCANInterface": {
                 "interfaceName": "vcan0",
                 "protocolName": "CAN",
                 "protocolVersion": "2.0A"
             },
             "interfaceId": "1",
-            "type": "canInterface"
+            "type": "socketCANInterface"
         },
         {
             "obdInterface": {

--- a/src/vehiclenetwork/CMakeLists.txt
+++ b/src/vehiclenetwork/CMakeLists.txt
@@ -6,7 +6,7 @@ set(libraryAliasName IoTFleetWise::Vehiclenetwork)
 
 
 set(SRCS
-  src/CANDataSource.cpp
+  src/SocketCANDataSource.cpp
   src/ISOTPOverCANReceiver.cpp
   src/ISOTPOverCANSender.cpp
   src/ISOTPOverCANSenderReceiver.cpp
@@ -62,7 +62,7 @@ install(
   include/businterfaces/ISOTPOverCANSenderReceiver.h
   include/businterfaces/AbstractVehicleDataSource.h
   include/businterfaces/VehicleDataSourceListener.h
-  include/businterfaces/CANDataSource.h
+  include/businterfaces/SocketCANDataSource.h
   DESTINATION
   include
 )
@@ -98,7 +98,7 @@ set(
   testSources
   test/ISOTPOverCANProtocolTest.cpp
   test/VehicleDataMessageTest.cpp
-  test/CANDataSourceTest.cpp
+  test/SocketCANDataSourceTest.cpp
 )
 
 if(FWE_FEATURE_CAMERA)

--- a/src/vehiclenetwork/include/businterfaces/SocketCANDataSource.h
+++ b/src/vehiclenetwork/include/businterfaces/SocketCANDataSource.h
@@ -58,7 +58,7 @@ stringToCanTimestampType( std::string const &timestampType, CAN_TIMESTAMP_TYPE &
  * @brief Linux CAN Bus implementation. Uses Raw Sockets to listen to CAN
  * data on 1 single CAN IF.
  */
-class CANDataSource : public AbstractVehicleDataSource
+class SocketCANDataSource : public AbstractVehicleDataSource
 {
 public:
     static constexpr int PARALLEL_RECEIVED_FRAMES_FROM_KERNEL = 10;
@@ -69,15 +69,15 @@ public:
      * @param timestampTypeToUse which timestamp type should be used to tag the can frames, this timestamp will be
      * visible in the cloud
      */
-    CANDataSource( CAN_TIMESTAMP_TYPE timestampTypeToUse );
-    CANDataSource();
+    SocketCANDataSource( CAN_TIMESTAMP_TYPE timestampTypeToUse );
+    SocketCANDataSource();
 
-    ~CANDataSource() override;
+    ~SocketCANDataSource() override;
 
-    CANDataSource( const CANDataSource & ) = delete;
-    CANDataSource &operator=( const CANDataSource & ) = delete;
-    CANDataSource( CANDataSource && ) = delete;
-    CANDataSource &operator=( CANDataSource && ) = delete;
+    SocketCANDataSource( const SocketCANDataSource & ) = delete;
+    SocketCANDataSource &operator=( const SocketCANDataSource & ) = delete;
+    SocketCANDataSource( SocketCANDataSource && ) = delete;
+    SocketCANDataSource &operator=( SocketCANDataSource && ) = delete;
 
     bool init( const std::vector<VehicleDataSourceConfig> &sourceConfigs ) override;
     bool connect() override;

--- a/src/vehiclenetwork/test/SocketCANDataSourceTest.cpp
+++ b/src/vehiclenetwork/test/SocketCANDataSourceTest.cpp
@@ -2,7 +2,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "businterfaces/CANDataSource.h"
+#include "businterfaces/SocketCANDataSource.h"
 #include <functional>
 #include <gtest/gtest.h>
 #include <linux/can.h>
@@ -142,7 +142,7 @@ sendTestMessageExtendedID( int socketFD )
     ASSERT_EQ( bytesWritten, sizeof( struct can_frame ) );
 }
 
-class CANDataSourceTest : public ::testing::Test
+class SocketCANDataSourceTest : public ::testing::Test
 {
 public:
     int socketFD;
@@ -165,7 +165,7 @@ protected:
     }
 };
 
-TEST_F( CANDataSourceTest, testAquireDataFromNetwork )
+TEST_F( SocketCANDataSourceTest, testAquireDataFromNetwork )
 {
     LocalDataSourceEventListener listener;
     ASSERT_TRUE( socketFD != -1 );
@@ -177,7 +177,7 @@ TEST_F( CANDataSourceTest, testAquireDataFromNetwork )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 
@@ -199,7 +199,7 @@ TEST_F( CANDataSourceTest, testAquireDataFromNetwork )
     ASSERT_TRUE( listener.gotDisConnectCallback );
 }
 
-TEST_F( CANDataSourceTest, testDoNotAcquireDataFromNetwork )
+TEST_F( SocketCANDataSourceTest, testDoNotAcquireDataFromNetwork )
 {
     LocalDataSourceEventListener listener;
     int socketFD = setup();
@@ -212,7 +212,7 @@ TEST_F( CANDataSourceTest, testDoNotAcquireDataFromNetwork )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 
@@ -237,7 +237,7 @@ TEST_F( CANDataSourceTest, testDoNotAcquireDataFromNetwork )
     ASSERT_TRUE( listener.gotDisConnectCallback );
 }
 
-TEST_F( CANDataSourceTest, testNetworkDataAquisitionStateChange )
+TEST_F( SocketCANDataSourceTest, testNetworkDataAquisitionStateChange )
 {
     // In this test, we want to start the channel with the default settings i.e. sleep mode,
     // then activate data acquisition and check that the channel buffer effectively has a message,
@@ -252,7 +252,7 @@ TEST_F( CANDataSourceTest, testNetworkDataAquisitionStateChange )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 
@@ -299,7 +299,7 @@ TEST_F( CANDataSourceTest, testNetworkDataAquisitionStateChange )
     ASSERT_TRUE( listener.gotDisConnectCallback );
 }
 
-TEST_F( CANDataSourceTest, testSourceIdsAreUnique )
+TEST_F( SocketCANDataSourceTest, testSourceIdsAreUnique )
 {
     ASSERT_TRUE( socketFD != -1 );
     static_cast<void>( socketFD >= 0 );
@@ -308,13 +308,13 @@ TEST_F( CANDataSourceTest, testSourceIdsAreUnique )
     std::unordered_set<VehicleDataSourceID> sourceIDs;
     for ( auto i = 0; i < NUM_SOURCES; ++i )
     {
-        CANDataSource source;
+        SocketCANDataSource source;
         sourceIDs.insert( source.getVehicleDataSourceID() );
     }
     ASSERT_EQ( NUM_SOURCES, sourceIDs.size() );
 }
 
-TEST_F( CANDataSourceTest, testCanFDSocketMode )
+TEST_F( SocketCANDataSourceTest, testCanFDSocketMode )
 {
     LocalDataSourceEventListener listener;
     int socketFD = setup( true );
@@ -327,7 +327,7 @@ TEST_F( CANDataSourceTest, testCanFDSocketMode )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 
@@ -353,7 +353,7 @@ TEST_F( CANDataSourceTest, testCanFDSocketMode )
     ASSERT_TRUE( listener.gotDisConnectCallback );
 }
 
-TEST_F( CANDataSourceTest, testSendRegularID )
+TEST_F( SocketCANDataSourceTest, testSendRegularID )
 {
     LocalDataSourceEventListener listener;
     ASSERT_TRUE( socketFD != -1 );
@@ -365,7 +365,7 @@ TEST_F( CANDataSourceTest, testSendRegularID )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 
@@ -388,7 +388,7 @@ TEST_F( CANDataSourceTest, testSendRegularID )
     ASSERT_TRUE( listener.gotDisConnectCallback );
 }
 
-TEST_F( CANDataSourceTest, testExtractExtendedID )
+TEST_F( SocketCANDataSourceTest, testExtractExtendedID )
 {
     LocalDataSourceEventListener listener;
     ASSERT_TRUE( socketFD != -1 );
@@ -400,7 +400,7 @@ TEST_F( CANDataSourceTest, testExtractExtendedID )
     sourceConfig.transportProperties.emplace( "threadIdleTimeMs", "1000" );
     sourceConfig.maxNumberOfVehicleDataMessages = 1000;
     std::vector<VehicleDataSourceConfig> sourceConfigs = { sourceConfig };
-    CANDataSource dataSource;
+    SocketCANDataSource dataSource;
     ASSERT_TRUE( dataSource.init( sourceConfigs ) );
     ASSERT_TRUE( dataSource.subscribeListener( &listener ) );
 

--- a/tools/configure-fwe.sh
+++ b/tools/configure-fwe.sh
@@ -81,7 +81,7 @@ parse_args() {
 
 parse_args "$@"
 
-if [ "`jq '.networkInterfaces[0].canInterface' ${INPUT_CONFIG_FILE}`" == "null" ] \
+if [ "`jq '.networkInterfaces[0].socketCANInterface' ${INPUT_CONFIG_FILE}`" == "null" ] \
     || [ "`jq '.networkInterfaces[1].obdInterface' ${INPUT_CONFIG_FILE}`" == "null" ]; then
     echo "Error: Unexpected format in input config file"
     exit -1
@@ -98,7 +98,7 @@ jq ".staticConfig.mqttConnection.endpointUrl=\"${ENDPOINT_URL}\"" ${INPUT_CONFIG
     | jq ".staticConfig.mqttConnection.privateKeyFilename=\"/etc/aws-iot-fleetwise/private-key.key\"" \
     | jq ".staticConfig.internalParameters.systemWideLogLevel=\"Info\"" \
     | jq ".staticConfig.persistency.persistencyPath=\"${PERSISTENCY_PATH}\"" \
-    | jq ".networkInterfaces[0].canInterface.interfaceName=\"${CAN_BUS0}\"" \
+    | jq ".networkInterfaces[0].socketCANInterface.interfaceName=\"${CAN_BUS0}\"" \
     | jq ".networkInterfaces[1].obdInterface.interfaceName=\"${CAN_BUS0}\"" \
     | jq ".networkInterfaces[1].obdInterface.pidRequestIntervalSeconds=5" \
     | jq ".networkInterfaces[1].obdInterface.dtcRequestIntervalSeconds=5" \


### PR DESCRIPTION
Renames `CANDataSource` to `SocketCANDataSource` to avoid potential ambiguity with other CAN based `DataSource`s.

Also renames `canInterface` to `socketCANInterface` for edge configurations where it could also be ambiguous.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.