### PR TITLE
Enable tests with faketime

### DIFF
--- a/tools/build-fwe-native.sh
+++ b/tools/build-fwe-native.sh
@@ -9,5 +9,6 @@ cmake \
   -DFWE_STATIC_LINK=On \
   -DFWE_STRIP_SYMBOLS=On \
   -DFWE_SECURITY_COMPILE_FLAGS=On \
+  -DFWE_TEST_FAKETIME=On \
   ..
 make -j`nproc`

--- a/tools/install-deps-cross-arm64.sh
+++ b/tools/install-deps-cross-arm64.sh
@@ -45,6 +45,7 @@ apt install -y \
     build-essential \
     crossbuild-essential-arm64 \
     cmake \
+    faketime:arm64 \
     unzip \
     git \
     wget \

--- a/tools/install-deps-cross-armhf.sh
+++ b/tools/install-deps-cross-armhf.sh
@@ -45,6 +45,7 @@ apt install -y \
     build-essential \
     crossbuild-essential-armhf \
     cmake \
+    faketime:armhf \
     unzip \
     git \
     wget \

--- a/tools/install-deps-native.sh
+++ b/tools/install-deps-native.sh
@@ -32,6 +32,7 @@ apt install -y \
     libboost-thread-dev \
     build-essential \
     cmake \
+    faketime \
     unzip \
     git \
     wget \


### PR DESCRIPTION
By default tests using the faketime to change the system time are disabled. This installs the dependency and enables the tests for GH Actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
