### PR TITLE
Bump isort version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - run: sudo apt-get install expect
       - run: pip install pre-commit
       - run: unbuffer pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black


### PR DESCRIPTION
The previous version has an incompatibility with the latest version
of poetry, which was making the isort installation fail:

https://github.com/PyCQA/isort/blob/main/CHANGELOG.md#5120-january-28-2023


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
