### PR TITLE
Fix cyclic systemd configuration for demo

### DIFF
--- a/docs/iwave-g26-tutorial/iwave-g26-tutorial.md
+++ b/docs/iwave-g26-tutorial/iwave-g26-tutorial.md
@@ -112,7 +112,7 @@ the steps below to be executed first.
    ```ini
    [Unit]
    Description=Setup SocketCAN interfaces
-   After=multi-user.target
+   After=network.target
    [Service]
    Type=oneshot
    RemainAfterExit=yes

--- a/tools/deploy/fwe@.service
+++ b/tools/deploy/fwe@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=AWS IoT FleetWise Edge #%i
-After=network-online.target
+After=network-online.target setup-socketcan.service
 Wants=network-online.target setup-socketcan.service
 
 [Service]

--- a/tools/install-socketcan.sh
+++ b/tools/install-socketcan.sh
@@ -81,7 +81,7 @@ done
 cat > /lib/systemd/system/setup-socketcan.service <<EOT
 [Unit]
 Description=Setup SocketCAN interfaces
-After=multi-user.target
+After=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/tools/yocto/sources/meta-aws-iot-fleetwise/recipes-extended/setup-socketcan/files/setup-socketcan.service
+++ b/tools/yocto/sources/meta-aws-iot-fleetwise/recipes-extended/setup-socketcan/files/setup-socketcan.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Setup SocketCAN interfaces
-After=multi-user.target
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I could reproduce https://github.com/aws/aws-iot-fleetwise-edge/issues/54 by restarting the EC2 simulation the edge. After removing the `After=multi-user.target` restarts went smooth