### PR TITLE
Switch to cmake for protobuf library build

### DIFF
--- a/tools/install-deps-cross-android.sh
+++ b/tools/install-deps-cross-android.sh
@@ -119,7 +119,13 @@ install_deps() {
     cd protobuf-${VERSION_PROTOBUF}
     if [ ! -f ${NATIVE_PREFIX}/bin/protoc ]; then
         mkdir build_native && cd build_native
-        ../configure --prefix=${NATIVE_PREFIX}
+        cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+            -Dprotobuf_BUILD_TESTS=Off \
+            -DCMAKE_INSTALL_PREFIX=${NATIVE_PREFIX} \
+            ..
         make install -j`nproc`
         cd ..
     fi
@@ -135,10 +141,18 @@ install_deps() {
         LD=${TOOLCHAIN}/bin/ld \
         RANLIB=${TOOLCHAIN}/bin/llvm-ranlib \
         STRIP=${TOOLCHAIN}/bin/llvm-strip \
-        ../configure \
-            --host=${HOST_PLATFORM} \
-            --prefix=${INSTALL_PREFIX} \
-            "CFLAGS=-fPIC" "CXXFLAGS=-fPIC"
+        cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+            -Dprotobuf_BUILD_TESTS=Off \
+            -DANDROID_ABI=${TARGET_ARCH} \
+            -DANDROID_PLATFORM=android-${VERSION_ANDROID_API} \
+            -DCMAKE_ANDROID_NDK=${SDK_PREFIX}/ndk/${VERSION_ANDROID_NDK} \
+            -DCMAKE_TOOLCHAIN_FILE=${SDK_PREFIX}/ndk/${VERSION_ANDROID_NDK}/build/cmake/android.toolchain.cmake \
+            -DANDROID_TOOLCHAIN=clang \
+            -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+            ..
     make install -j`nproc`
     cd ../..
 

--- a/tools/install-deps-cross-arm64.sh
+++ b/tools/install-deps-cross-arm64.sh
@@ -44,6 +44,7 @@ sed -i "s/deb http/deb [arch=${ARCH}] http/g" /etc/apt/sources.list
 cp /etc/apt/sources.list /etc/apt/sources.list.d/arm64.list
 sed -i "s/deb \[arch=${ARCH}\] http/deb [arch=arm64] http/g" /etc/apt/sources.list.d/arm64.list
 sed -i -E "s#(archive|security).ubuntu.com/ubuntu#ports.ubuntu.com/ubuntu-ports#g" /etc/apt/sources.list.d/arm64.list
+cat /etc/apt/sources.list.d/arm64.list
 dpkg --add-architecture arm64
 apt update
 apt install -y \

--- a/tools/install-deps-cross-arm64.sh
+++ b/tools/install-deps-cross-arm64.sh
@@ -99,12 +99,24 @@ if ! ${USE_CACHE} || [ ! -d /usr/local/aarch64-linux-gnu ] || [ ! -d ${NATIVE_PR
     tar -zxf protobuf-cpp-${VERSION_PROTOBUF}.tar.gz
     cd protobuf-${VERSION_PROTOBUF}
     mkdir build && cd build
-    ../configure --prefix=${NATIVE_PREFIX}
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+        -Dprotobuf_BUILD_TESTS=Off \
+        -DCMAKE_INSTALL_PREFIX=${NATIVE_PREFIX} \
+        ..
     make install -j`nproc`
     cd ..
     mkdir build_arm64 && cd build_arm64
-    CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ \
-        ../configure --host=aarch64-linux --prefix=/usr/local/aarch64-linux-gnu
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+        -Dprotobuf_BUILD_TESTS=Off \
+        -DCMAKE_TOOLCHAIN_FILE=/usr/local/aarch64-linux-gnu/lib/cmake/arm64-toolchain.cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/local/aarch64-linux-gnu \
+        ..
     make install -j`nproc`
     cd ../..
 

--- a/tools/install-deps-cross-armhf.sh
+++ b/tools/install-deps-cross-armhf.sh
@@ -99,12 +99,24 @@ if ! ${USE_CACHE} || [ ! -d /usr/local/arm-linux-gnueabihf ] || [ ! -d ${NATIVE_
     tar -zxf protobuf-cpp-${VERSION_PROTOBUF}.tar.gz
     cd protobuf-${VERSION_PROTOBUF}
     mkdir build && cd build
-    ../configure --prefix=${NATIVE_PREFIX}
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+        -Dprotobuf_BUILD_TESTS=Off \
+        -DCMAKE_INSTALL_PREFIX=${NATIVE_PREFIX} \
+        ..
     make install -j`nproc`
     cd ..
     mkdir build_armhf && cd build_armhf
-    CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ \
-        ../configure --host=arm-linux --prefix=/usr/local/arm-linux-gnueabihf
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+        -Dprotobuf_BUILD_TESTS=Off \
+        -DCMAKE_TOOLCHAIN_FILE=/usr/local/arm-linux-gnueabihf/lib/cmake/armhf-toolchain.cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/local/arm-linux-gnueabihf \
+        ..
     make install -j`nproc`
     cd ../..
 

--- a/tools/install-deps-native.sh
+++ b/tools/install-deps-native.sh
@@ -97,7 +97,13 @@ if ${INSTALL_BUILD_TIME_DEPS} && ( ! ${USE_CACHE} || [ ! -d ${PREFIX} ] ); then
     tar -zxf protobuf-cpp-${VERSION_PROTOBUF}.tar.gz
     cd protobuf-${VERSION_PROTOBUF}
     mkdir build && cd build
-    ../configure --prefix=${PREFIX}
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=On \
+        -Dprotobuf_BUILD_TESTS=Off \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        ..
     make install -j`nproc`
     cd ../..
 


### PR DESCRIPTION
This pull request are making changes to the install dependency scripts. It will make two chagnes:
1. Switch to CMake for protobuf library build
2. Enable CMake option `DCMAKE_POSITION_INDEPENDENT_CODE` so that the static library can be consumed by shared target build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
