### PR TITLE
Modified print syntax

### DIFF
--- a/tools/cloud/dbc-to-decoders.py
+++ b/tools/cloud/dbc-to-decoders.py
@@ -59,7 +59,9 @@ for message in db.messages:
 out = json.dumps(signal_decoders_to_add, indent=4, sort_keys=True)
 
 if len(sys.argv) < 3:
-    print(out)
+    # print(out)
+    # When you run a demo.sh, the script automatically shuts down when the output appears.
+    pass
 else:
     with open(sys.argv[2], "w") as fp:
         fp.write(out)

--- a/tools/cloud/dbc-to-nodes.py
+++ b/tools/cloud/dbc-to-nodes.py
@@ -71,7 +71,9 @@ for message in db.messages:
 out = json.dumps(nodes, indent=4, sort_keys=True)
 
 if len(sys.argv) < 3:
-    print(out)
+    # print(out)
+    # When you run a demo.sh, the script automatically shuts down when the output appears.
+    pass
 else:
     with open(sys.argv[2], "w") as fp:
         fp.write(out)


### PR DESCRIPTION
When you run the demo.sh, the script shuts down when you see the output syntax; modify the dbc-to-nodes.py and dbc-to-decoders.py files to avoid outputting the results.
