### PR TITLE
Add us-west-2 and ap-south-1 regions for testing purposes

### DIFF
--- a/tools/cfn-templates/fwdemo.yml
+++ b/tools/cfn-templates/fwdemo.yml
@@ -28,12 +28,15 @@ Parameters:
   IoTCoreRegion:
     Description:
       "Region in which to create IoT Things. This must be the same region used to create IoT
-      FleetWise Vehicles."
+      FleetWise Vehicles. Refer to https://docs.aws.amazon.com/general/latest/gr/iotfleetwise.html
+      to find the list of available regions."
     Type: String
     Default: "us-east-1"
     AllowedValues:
       - "us-east-1"
       - "eu-central-1"
+      - "us-west-2"
+      - "ap-south-1"
   IoTCoreEndpointUrl:
     Description: "Endpoint URL for IoT Core (leave blank for automatic)"
     Type: String


### PR DESCRIPTION
AWS IoT FleetWise is currently not generally available in these regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
