### PR TITLE
Fix GitHub apt repo mirror sync issues for arm64/armhf by using ports.ubuntu.com

### DIFF
--- a/tools/arm64.list
+++ b/tools/arm64.list
@@ -1,0 +1,4 @@
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse

--- a/tools/armhf.list
+++ b/tools/armhf.list
@@ -1,0 +1,4 @@
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse
+deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse

--- a/tools/install-deps-cross-arm64.sh
+++ b/tools/install-deps-cross-arm64.sh
@@ -80,27 +80,13 @@ print_file() {
 
 print_file "Before patching" /etc/apt/sources.list
 sed -i -E "s/deb (http|mirror\+file)/deb [arch=${ARCH}] \1/g" /etc/apt/sources.list
-cp /etc/apt/sources.list /etc/apt/sources.list.d/arm64.list
-sed -i -E "s/deb \[arch=${ARCH}\] (http|mirror\+file)/deb [arch=arm64] \1/g" /etc/apt/sources.list.d/arm64.list
-# GitHub uses a separate mirrors file
-if [ -f /etc/apt/apt-mirrors.txt ]; then
-    print_file "Before patching" /etc/apt/apt-mirrors.txt
-    cp /etc/apt/apt-mirrors.txt /etc/apt/apt-mirrors-arm64.txt
-    sed -i "s#/etc/apt/apt-mirrors.txt#/etc/apt/apt-mirrors-arm64.txt#g" /etc/apt/sources.list.d/arm64.list
-    PATCH_FILE="/etc/apt/apt-mirrors-arm64.txt"
-    sed -i -E "s#(archive|security).ubuntu.com/ubuntu#ports.ubuntu.com/ubuntu-ports#g" /etc/apt/sources.list.d/arm64.list
-    print_file "After patching" /etc/apt/apt-mirrors-arm64.txt
-else
-    PATCH_FILE="/etc/apt/sources.list.d/arm64.list"
-fi
-sed -i -E "s#(archive|security).ubuntu.com/ubuntu#ports.ubuntu.com/ubuntu-ports#g" ${PATCH_FILE}
-print_file "After patching" /etc/apt/sources.list.d/arm64.list
+print_file "After patching" /etc/apt/sources.list
 
+cp ${SCRIPT_DIR}/arm64.list /etc/apt/sources.list.d/
 dpkg --add-architecture arm64
 apt-get update
 apt-get install -y \
-    build-essential
-apt-get install -y \
+    build-essential \
     cmake \
     crossbuild-essential-arm64 \
     curl \

--- a/tools/install-deps-cross-armhf.sh
+++ b/tools/install-deps-cross-armhf.sh
@@ -80,27 +80,13 @@ print_file() {
 
 print_file "Before patching" /etc/apt/sources.list
 sed -i -E "s/deb (http|mirror\+file)/deb [arch=${ARCH}] \1/g" /etc/apt/sources.list
-cp /etc/apt/sources.list /etc/apt/sources.list.d/armhf.list
-sed -i -E "s/deb \[arch=${ARCH}\] (http|mirror\+file)/deb [arch=armhf] \1/g" /etc/apt/sources.list.d/armhf.list
-# GitHub uses a separate mirrors file
-if [ -f /etc/apt/apt-mirrors.txt ]; then
-    print_file "Before patching" /etc/apt/apt-mirrors.txt
-    cp /etc/apt/apt-mirrors.txt /etc/apt/apt-mirrors-armhf.txt
-    sed -i "s#/etc/apt/apt-mirrors.txt#/etc/apt/apt-mirrors-armhf.txt#g" /etc/apt/sources.list.d/armhf.list
-    PATCH_FILE="/etc/apt/apt-mirrors-armhf.txt"
-    sed -i -E "s#(archive|security).ubuntu.com/ubuntu#ports.ubuntu.com/ubuntu-ports#g" /etc/apt/sources.list.d/armhf.list
-    print_file "After patching" /etc/apt/apt-mirrors-armhf.txt
-else
-    PATCH_FILE="/etc/apt/sources.list.d/armhf.list"
-fi
-sed -i -E "s#(archive|security).ubuntu.com/ubuntu#ports.ubuntu.com/ubuntu-ports#g" ${PATCH_FILE}
-print_file "After patching" /etc/apt/sources.list.d/armhf.list
+print_file "After patching" /etc/apt/sources.list
 
+cp ${SCRIPT_DIR}/armhf.list /etc/apt/sources.list.d/
 dpkg --add-architecture armhf
 apt-get update
 apt-get install -y \
-    build-essential
-apt-get install -y \
+    build-essential \
     cmake \
     crossbuild-essential-armhf \
     curl \


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
